### PR TITLE
Add floating 3D objects to hero

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-slick": "^0.30.3",
-    "slick-carousel": "^1.8.1"
+    "slick-carousel": "^1.8.1",
+    "three": "^0.164.0",
+    "@react-three/fiber": "^8.16.1",
+    "@react-three/drei": "^9.88.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/components/Hero/FloatingObjects.tsx
+++ b/src/components/Hero/FloatingObjects.tsx
@@ -1,0 +1,43 @@
+import React, { useRef } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { Float } from '@react-three/drei';
+import { Mesh } from 'three';
+
+const RotatingTetrahedron: React.FC = () => {
+  const ref = useRef<Mesh>(null!);
+  useFrame(() => {
+    if (ref.current) {
+      ref.current.rotation.x += 0.01;
+      ref.current.rotation.y += 0.01;
+    }
+  });
+  return (
+    <mesh ref={ref} position={[0, -1, 0]}>
+      <tetrahedronGeometry args={[0.8]} />
+      <meshStandardMaterial color="#ff8c00" />
+    </mesh>
+  );
+};
+
+const FloatingObjects: React.FC = () => {
+  return (
+    <Canvas className="floatingCanvas" camera={{ position: [0, 0, 5] }}>
+      <ambientLight intensity={0.5} />
+      <Float floatIntensity={2} rotationIntensity={1}>
+        <mesh position={[-1.5, 0.5, 0]}>
+          <boxGeometry args={[1, 1, 1]} />
+          <meshStandardMaterial color="#e9ff47" />
+        </mesh>
+      </Float>
+      <Float floatIntensity={2} rotationIntensity={1}>
+        <mesh position={[1.5, 0, 0]}>
+          <sphereGeometry args={[0.6, 32, 32]} />
+          <meshStandardMaterial color="#e9ff47" />
+        </mesh>
+      </Float>
+      <RotatingTetrahedron />
+    </Canvas>
+  );
+};
+
+export default FloatingObjects;

--- a/src/components/Hero/Hero.module.css
+++ b/src/components/Hero/Hero.module.css
@@ -2,11 +2,14 @@
     background-color: var(--color-bg-light);
     padding: 100px 20px;
     text-align: center;
+    position: relative;
   }
   
   .content {
     max-width: 800px;
     margin: 0 auto;
+    position: relative;
+    z-index: 1;
   }
   
   h1 {
@@ -15,6 +18,7 @@
     line-height: 1.2;
     margin-bottom: 24px;
     color: var(--color-text);
+    white-space: pre-line;
   }
   
   p {
@@ -37,6 +41,15 @@
   
   button:hover {
     opacity: 0.9;
+  }
+
+  .floatingCanvas {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 0;
+    pointer-events: none;
   }
   
   

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import styles from './Hero.module.css';
+import FloatingObjects from './FloatingObjects';
 
 const Hero: React.FC = () => {
   return (
     <section className={styles.hero}>
+      <FloatingObjects />
       <div className={styles.content}>
         <h1>
           Профессия "Продакт-менеджер" с нуля <br />


### PR DESCRIPTION
## Summary
- install three.js libs
- add `FloatingObjects` component with React Three Fiber
- show floating 3D shapes behind hero text
- style hero section to position 3D canvas

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6842d890a3408320be9e22e5d81fd743