### PR TITLE
Add consultation form to header

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,11 +1,21 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styles from './Header.module.css';
+import ConsultationForm from '../ConsultationForm/ConsultationForm';
 
 const Header: React.FC = () => {
+  const [showForm, setShowForm] = useState(false);
   return (
     <header className={styles.header}>
+      {showForm && (
+        <ConsultationForm onClose={() => setShowForm(false)} />
+      )}
       <div className={styles.logo}>One to One</div>
-      <button className={styles.button}>Записаться</button>
+      <button
+        className={styles.button}
+        onClick={() => setShowForm(true)}
+      >
+        Записаться
+      </button>
     </header>
   );
 };


### PR DESCRIPTION
## Summary
- allow opening the consultation form from the site header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846af8a03c4832092487575e1ce6ffd