### PR TITLE
Enhance Concept block slider

### DIFF
--- a/src/components/Concept/Concept.module.css
+++ b/src/components/Concept/Concept.module.css
@@ -48,12 +48,12 @@
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.05);
   overflow: hidden;
   text-align: center;
-  padding: 24px;
+  padding: 32px;
 }
 
 .image {
   width: 100%;
-  height: 200px;
+  height: 280px;
   object-fit: cover;
   border-radius: 12px;
   margin-bottom: 16px;
@@ -69,4 +69,15 @@
 .cardSubtitle {
   font-size: 14px;
   color: #666;
+}
+
+/* Увеличенные точки пагинации */
+.slider :global(.swiper-pagination-bullet) {
+  width: 16px;
+  height: 16px;
+  margin: 0 6px;
+}
+
+.slider :global(.swiper-pagination-bullet-active) {
+  background-color: var(--color-accent);
 }

--- a/src/components/Concept/Concept.tsx
+++ b/src/components/Concept/Concept.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
-import { Pagination } from 'swiper/modules';
+import { Pagination, Keyboard } from 'swiper/modules';
 import 'swiper/css';
 import 'swiper/css/pagination';
 import styles from './Concept.module.css';
@@ -52,10 +52,11 @@ const Concept: FC = () => {
       </div>
       <Swiper
         className={styles.slider}
-        modules={[Pagination]}
+        modules={[Pagination, Keyboard]}
         spaceBetween={24}
         slidesPerView={1}
         pagination={{ clickable: true }}
+        keyboard={{ enabled: true }}
       >
         {slides.map((slide) => (
           <SwiperSlide key={slide.title} className={styles.slide}>


### PR DESCRIPTION
## Summary
- enlarge Concept slider cards and pagination dots
- enable keyboard navigation in the Concept slider

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848641f3e308320962005a97bb57b6c