### PR TITLE
Add card click navigation in Concept block

### DIFF
--- a/src/components/Concept/Concept.module.css
+++ b/src/components/Concept/Concept.module.css
@@ -49,6 +49,7 @@
   overflow: hidden;
   text-align: center;
   padding: 32px;
+  cursor: pointer;
 }
 
 .image {

--- a/src/components/Concept/Concept.tsx
+++ b/src/components/Concept/Concept.tsx
@@ -1,5 +1,6 @@
-import { FC } from 'react';
+import { FC, useRef } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
+import type { Swiper as SwiperType } from 'swiper';
 import { Pagination, Keyboard } from 'swiper/modules';
 import 'swiper/css';
 import 'swiper/css/pagination';
@@ -40,6 +41,8 @@ const slides: Slide[] = [
 ];
 
 const Concept: FC = () => {
+  const swiperRef = useRef<SwiperType>();
+
   return (
     <section className={styles.concept}>
       <div className={styles.textBlock}>
@@ -57,10 +60,16 @@ const Concept: FC = () => {
         slidesPerView={1}
         pagination={{ clickable: true }}
         keyboard={{ enabled: true }}
+        onSwiper={(swiper) => {
+          swiperRef.current = swiper;
+        }}
       >
         {slides.map((slide) => (
           <SwiperSlide key={slide.title} className={styles.slide}>
-            <div className={styles.card}>
+            <div
+              className={styles.card}
+              onClick={() => swiperRef.current?.slideNext()}
+            >
               <img src={slide.image} alt={slide.title} className={styles.image} />
               <h3 className={styles.cardTitle}>{slide.title}</h3>
               <p className={styles.cardSubtitle}>{slide.subtitle}</p>


### PR DESCRIPTION
## Summary
- enable card click navigation in Concept swiper
- indicate cards are clickable with a pointer cursor

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_684865d990d483208f8d0bcb704ff611