### PR TITLE
Fix FC usage in Concept component

### DIFF
--- a/src/components/Concept/Concept.tsx
+++ b/src/components/Concept/Concept.tsx
@@ -1,4 +1,4 @@
-import { FC, useRef } from 'react';
+import React, { useRef } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import type { Swiper as SwiperType } from 'swiper';
 import { Pagination, Keyboard } from 'swiper/modules';
@@ -40,8 +40,8 @@ const slides: Slide[] = [
   },
 ];
 
-const Concept: FC = () => {
-  const swiperRef = useRef<SwiperType>();
+const Concept: React.FC = () => {
+  const swiperRef = useRef<SwiperType | null>(null);
 
   return (
     <section className={styles.concept}>


### PR DESCRIPTION
## Summary
- import React default instead of importing `FC`
- initialize Swiper ref with `null` type

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68497ae9ed508320a4e9a7aae5c4aa4f