### PR TITLE
Fix concept slider bullet color

### DIFF
--- a/src/components/Concept/Concept.module.css
+++ b/src/components/Concept/Concept.module.css
@@ -83,5 +83,5 @@
 }
 
 .slider :global(.swiper-pagination-bullet-active) {
-  background-color: var(--color-accent);
+  background-color: var(--color-text);
 }


### PR DESCRIPTION
## Summary
- match slider pagination dot with text color in Concept section

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68499dba8c4c832090eb3d4d4cfa355e