### PR TITLE
Adjust hero image positioning

### DIFF
--- a/src/components/Hero/Hero.module.css
+++ b/src/components/Hero/Hero.module.css
@@ -64,11 +64,17 @@
   background-color: #333;
 }
 
+
 .imageContainer {
   flex: 1;
   min-width: 280px;
   display: flex;
   justify-content: flex-end;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  align-items: flex-end;
 }
 
 .imageContainer img {
@@ -78,6 +84,9 @@
 }
 
 .heroImage {
-  max-width: 100%;
+  max-width: none;
+  width: 100%;
   height: auto;
+  transform: scale(2);
+  transform-origin: bottom center;
 }


### PR DESCRIPTION
## Summary
- let the hero image fill the width and stick to the bottom
- double its scale so it stands out more

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6849ad8dea00832084f9e5046c481ce7