### PR TITLE
Adjust concept padding

### DIFF
--- a/src/components/Concept/Concept.module.css
+++ b/src/components/Concept/Concept.module.css
@@ -3,7 +3,7 @@
   display: grid;
   grid-template-columns: 1fr;
   gap: 40px;
-  padding: 60px 20px;
+  padding: 60px 40px 60px 20px;
   width: 100%;
   font-family: 'Inter', sans-serif;
   background-color: var(--color-bg-white);


### PR DESCRIPTION
## Summary
- tweak padding for `.concept` so the text isn't flush to the right edge

## Testing
- `npm run build` *(fails: Cannot find module 'react', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_684a90c5d8cc8320b4215fd1441ac0db