### PR TITLE
Fix Concept padding

### DIFF
--- a/src/components/Concept/Concept.module.css
+++ b/src/components/Concept/Concept.module.css
@@ -3,7 +3,7 @@
   display: grid;
   grid-template-columns: 1fr;
   gap: 40px;
-  padding: 60px 40px 60px 20px;
+  padding: 60px 40px 60px 40px;
   width: 100%;
   font-family: 'Inter', sans-serif;
   background-color: var(--color-bg-white);


### PR DESCRIPTION
## Summary
- adjust Concept section padding so text isn't flush against the left edge

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a91ab3e908320bccabd7b0fbf2b02