### PR TITLE
Update concept cards to match hero style

### DIFF
--- a/src/components/Concept/Concept.module.css
+++ b/src/components/Concept/Concept.module.css
@@ -42,17 +42,18 @@
     width: 100%;
   }
   
-  .card {
-    background: rgba(255, 255, 255, 0.6); /* Более плотный белый */
-    backdrop-filter: blur(16px);
-    -webkit-backdrop-filter: blur(16px);
-    border: 1px solid rgba(200, 200, 200, 0.4); /* Светлая стеклянная рамка */
+.card {
+    /* Стиль стеклянных карточек как в блоке Hero */
+    background: rgba(255, 255, 255, 0.2);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.3);
     border-radius: 24px;
     overflow: hidden;
     text-align: center;
     padding: 40px 24px;
     cursor: pointer;
-    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.2); /* Глубокая тень */
+    box-shadow: 0 8px 40px rgba(0, 0, 0, 0.15);
     transition: transform 0.3s ease, opacity 0.3s ease;
   }
   


### PR DESCRIPTION
## Summary
- align Concept card styles with glass effect from Hero block

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684adec8f108832087656701c557ed82