### PR TITLE
Fix concept image layering

### DIFF
--- a/src/components/Concept/Concept.module.css
+++ b/src/components/Concept/Concept.module.css
@@ -67,7 +67,7 @@
     -webkit-backdrop-filter: blur(10px);
     box-shadow: 0 8px 40px rgba(0, 0, 0, 0.15);
     pointer-events: none;
-    z-index: 1;
+    z-index: 0;
   }
   
   .card:hover {
@@ -77,12 +77,12 @@
   
   .image {
     position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
+    inset: 12px;
+    width: calc(100% - 24px);
+    height: calc(100% - 24px);
     object-fit: cover;
-    border-radius: 24px;
-    z-index: 0;
+    border-radius: 16px;
+    z-index: 1;
   }
   
   .cardTitle {


### PR DESCRIPTION
## Summary
- adjust layering for glass card so photo sits above the glass
- add inset spacing around the concept slide images

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies for React and others)*

------
https://chatgpt.com/codex/tasks/task_e_684ae1c49fac83209dd737fab49ab498