### PR TITLE
Fix Concept card shadow

### DIFF
--- a/src/components/Concept/Concept.module.css
+++ b/src/components/Concept/Concept.module.css
@@ -42,7 +42,7 @@
     width: 100%;
   }
   
-  .card {
+.card {
     /* Стиль стеклянных карточек как в блоке Hero */
     position: relative;
     display: flex;
@@ -54,6 +54,12 @@
     padding: 40px 24px;
     text-align: center;
     cursor: pointer;
+    border-radius: 24px;
+    background: rgba(255, 255, 255, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-shadow: 0 8px 40px rgba(0, 0, 0, 0.15);
   }
 
   .card::before {
@@ -65,7 +71,6 @@
     border-radius: 24px;
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
-    box-shadow: 0 8px 40px rgba(0, 0, 0, 0.15);
     pointer-events: none;
     z-index: 0;
   }


### PR DESCRIPTION
## Summary
- use same shadow style as hero cards for Concept section

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ae398e1548320a240c934e3dcf45e