### PR TITLE
Center Concept swiper dots

### DIFF
--- a/src/components/Concept/Concept.module.css
+++ b/src/components/Concept/Concept.module.css
@@ -110,6 +110,8 @@
   transform: translateX(-50%);
   display: flex;
   gap: 8px;
+  width: fit-content;
+  justify-content: center;
   padding: 4px 12px;
   background: rgba(255, 255, 255, 0.2);
   border-radius: 12px;


### PR DESCRIPTION
## Summary
- adjust `.swiper-pagination` styling so slider dots appear centered

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68512401bcc8832093fbb9793411d149