### PR TITLE
Increase Concept block spacing

### DIFF
--- a/src/components/Concept/Concept.module.css
+++ b/src/components/Concept/Concept.module.css
@@ -1,9 +1,9 @@
-.concept {
+  .concept {
     min-height: 100vh;
     display: flex;
     flex-direction: column;
     gap: 40px;
-    padding: 60px 0;
+    padding: 60px 0 100px; /* extra bottom space so pagination isn't flush */
     width: 100%;
     font-family: 'Inter', sans-serif;
     background: linear-gradient(to bottom, #f0f0f0 0%, #ffffff 100%);


### PR DESCRIPTION
## Summary
- add extra bottom padding to the Concept section so pagination isn't flush with the next block

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851294652788320a1630a677229a675