### PR TITLE
Fix spacing between Concept and AboutProgram

### DIFF
--- a/src/components/Concept/Concept.module.css
+++ b/src/components/Concept/Concept.module.css
@@ -3,8 +3,8 @@
     display: flex;
     flex-direction: column;
     gap: 40px;
-    padding: 40px 0 0; /* Убираем нижний внутренний отступ */
-    margin-bottom: 100px; /* Добавляем белую зону вниз */
+    padding: 40px 0 100px; /* Белый отступ теперь внутри блока */
+    margin-bottom: 0; /* Убрали внешний отступ */
     width: 100%;
     font-family: 'Inter', sans-serif;
     background: linear-gradient(to bottom, #f0f0f0 0%, #ffffff 100%);


### PR DESCRIPTION
## Summary
- remove external margin on the Concept section
- add internal padding so the spacing belongs to Concept

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68516157715883208d001a36863a435f