### PR TITLE
Fix spacing between Concept and AboutProgram sections

### DIFF
--- a/src/components/AboutProgram/AboutProgram.module.css
+++ b/src/components/AboutProgram/AboutProgram.module.css
@@ -1,6 +1,6 @@
 .aboutProgram {
     margin-top: 0;          /* Никакого внешнего отступа вверх */
-    padding-top: 100px;     /* Внутренний отступ, чтобы контент не прилипал */
+    padding-top: 40px;      /* Меньший внутренний отступ */
     background: linear-gradient(to bottom, #f0f0f0 0%, #ffffff 100%);
     position: relative;
     z-index: 2;

--- a/src/components/Concept/Concept.module.css
+++ b/src/components/Concept/Concept.module.css
@@ -4,7 +4,7 @@
     flex-direction: column;
     gap: 40px;
     padding: 40px 0 0; /* Убираем нижний внутренний отступ */
-    margin-bottom: 100px; /* Добавляем белую зону вниз */
+    margin-bottom: 0; /* Убираем лишний отступ вниз */
     width: 100%;
     font-family: 'Inter', sans-serif;
     background: linear-gradient(to bottom, #f0f0f0 0%, #ffffff 100%);
@@ -136,15 +136,6 @@
     filter: blur(4px);
   }
 
-  .concept::after {
-    content: "";
-    position: absolute;
-    bottom: -60px; /* тянется в AboutProgram */
-    left: 0;
-    width: 100%;
-    height: 80px;
-    background: linear-gradient(to bottom, #ffffff 0%, #ffffff 100%);
-    z-index: 0;
-  }
+  /* Псевдоэлемент убран, чтобы не оставался белый градиент между секциями */
   
   


### PR DESCRIPTION
## Summary
- remove bottom margin from `Concept` section and drop pseudo-element
- reduce top padding of `AboutProgram`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68517691a6348320a8f76b3a1ccfa125