### PR TITLE
Fix AboutProgram button sizing

### DIFF
--- a/src/components/AboutProgram/AboutProgram.module.css
+++ b/src/components/AboutProgram/AboutProgram.module.css
@@ -69,8 +69,8 @@
     background-color: #111;
     color: #fff;
     font-weight: 500;
-    padding: 14px 28px;
-    font-size: 16px;
+    padding: 12px 24px;
+    font-size: 14px;
     border: none;
     border-radius: 8px;
     cursor: pointer;


### PR DESCRIPTION
## Summary
- match AboutProgram button padding and font size with the Header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68529e4b69248320b5c6a989ba15b002