### PR TITLE
Add Getting Started instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,20 @@ Currently, two official plugins are available:
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 
+## Getting Started
+
+Install the project dependencies with:
+
+```bash
+npm install
+```
+
+After installation, start the development server:
+
+```bash
+npm run dev
+```
+
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:


### PR DESCRIPTION
## Summary
- add a Getting Started section to README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6852a00b483883208d00b900998fff86