### PR TITLE
Swap gradient direction for CourseStructure block

### DIFF
--- a/src/components/CourseStructure/CourseStructure.module.css
+++ b/src/components/CourseStructure/CourseStructure.module.css
@@ -1,6 +1,7 @@
   .structure {
       min-height: 100vh;
-      background: linear-gradient(to bottom, #ffffff 0%, #f0f0f0 100%);
+  /* Gradient starts with a soft grey at the top and fades to white */
+  background: linear-gradient(to bottom, #f0f0f0 0%, #ffffff 100%);
       padding: 100px 20px;
     }
   


### PR DESCRIPTION
## Summary
- reverse the gradient direction so CourseStructure begins grey and fades to white

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6853f478f3e0832087dc0864ff4a6bcf