### PR TITLE
Update fifth Concept slide to use image

### DIFF
--- a/src/components/Concept/Concept.tsx
+++ b/src/components/Concept/Concept.tsx
@@ -9,6 +9,7 @@ import sozvonImg from '../../assets/images/concept/sozvon.jpg';
 import shareImg from '../../assets/images/concept/Share.jpg'; // ← новая картинка
 import prostoImg from '../../assets/images/concept/prosto.jpg';
 import fingersImg from '../../assets/images/concept/fingers.jpg';
+import lightImg from '../../assets/images/concept/light.jpg';
 
 const slides = [
   {
@@ -35,6 +36,7 @@ const slides = [
     size: 'full',
   },
   {
+    image: lightImg,
     title: 'Ты делаешь, он направляет',
     subtitle: 'Работа над реальными задачами',
     size: 'seventy',


### PR DESCRIPTION
## Summary
- add `light.jpg` to Concept imports
- show `light.jpg` in fifth slide with overlay text

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68594fc3f3188320a795f8dd311e9fb3