### PR TITLE
Adjust concept pagination position

### DIFF
--- a/src/components/Concept/Concept.module.css
+++ b/src/components/Concept/Concept.module.css
@@ -39,7 +39,7 @@
   
   .slider {
     width: 100vw;
-    padding: 20px 0;
+    padding: 20px 0 40px;
     overflow: hidden;
     display: flex;
     align-items: center;
@@ -155,6 +155,10 @@
     border-radius: 50%;
     background: #bfbfbf;
     opacity: 1;
+  }
+
+  :global(.swiper-pagination) {
+    bottom: 0;
   }
 
   :global(.swiper-pagination-bullet-active) {


### PR DESCRIPTION
## Summary
- tweak Concept block styles so pagination dots sit slightly lower

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68596160a31483208c54671e65f33efd