### PR TITLE
Adjust Concept slider dots

### DIFF
--- a/src/components/Concept/Concept.module.css
+++ b/src/components/Concept/Concept.module.css
@@ -158,7 +158,7 @@
   }
 
   :global(.swiper-pagination) {
-    bottom: 0;
+    bottom: -20px; /* Position dots slightly lower */
   }
 
   :global(.swiper-pagination-bullet-active) {


### PR DESCRIPTION
## Summary
- lower Concept slider navigation dots by 20px

## Testing
- `npm run lint` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d1607c63c832081f74ab9bcac5c91