### PR TITLE
Shift Concept slider dots right

### DIFF
--- a/src/components/Concept/Concept.module.css
+++ b/src/components/Concept/Concept.module.css
@@ -157,9 +157,12 @@
     opacity: 1;
   }
 
-  :global(.swiper-pagination) {
-    bottom: -40px; /* Position dots slightly lower */
-  }
+:global(.swiper-pagination) {
+  bottom: -40px; /* Position dots slightly lower */
+  /* Align pagination dots to the right side */
+  text-align: right;
+  padding-right: 40px;
+}
 
   :global(.swiper-pagination-bullet-active) {
     background: #000;


### PR DESCRIPTION
## Summary
- adjust Concept slider pagination styling to right-align dots

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d1f4209b48320a88a9f196204c8c9