### PR TITLE
Adjust neon line position in AboutProgram

### DIFF
--- a/src/components/AboutProgram/AboutProgram.module.css
+++ b/src/components/AboutProgram/AboutProgram.module.css
@@ -89,7 +89,8 @@
 
 .neonLine {
   position: absolute;
-  bottom: 40px;
+  top: 50%;
+  transform: translateY(-50%);
   width: 100%;
   height: 40px;
   filter: blur(4px);


### PR DESCRIPTION
## Summary
- update `AboutProgram.module.css` so the neon line aligns with the cards' center

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e753ae2a48320991f82b7958e7e87