### PR TITLE
Fix concept slider dots position

### DIFF
--- a/src/components/Concept/Concept.module.css
+++ b/src/components/Concept/Concept.module.css
@@ -158,7 +158,7 @@
   }
 
 :global(.swiper-pagination) {
-  bottom: -40px; /* Position dots slightly lower */
+  bottom: -42px; /* Position dots a bit lower */
   /* Align pagination dots to the right side */
   text-align: right;
   padding-right: 40px;


### PR DESCRIPTION
## Summary
- shift slider pagination dots down by 2px in Concept section

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6864e38e595c83209e58e17166b1c5cf