### PR TITLE
Fix neon line position in AboutProgram

### DIFF
--- a/src/components/AboutProgram/AboutProgram.module.css
+++ b/src/components/AboutProgram/AboutProgram.module.css
@@ -89,7 +89,7 @@
 
 .neonLine {
   position: absolute;
-  bottom: 40px;
+  bottom: 42px;
   width: 100%;
   height: 40px;
   filter: blur(4px);


### PR DESCRIPTION
## Summary
- move the neon line a couple of pixels higher in the AboutProgram block

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6864e5ea4ccc8320b6f7e5ebd1206618