### PR TITLE
Adjust AboutProgram card opacity

### DIFF
--- a/src/components/AboutProgram/AboutProgram.module.css
+++ b/src/components/AboutProgram/AboutProgram.module.css
@@ -29,6 +29,7 @@
   
   .card {
     background-color: #fff;
+    opacity: 1;
     padding: 30px;
     border-radius: 20px;
     border: 1px solid #e0e0e0;


### PR DESCRIPTION
## Summary
- ensure AboutProgram cards are fully opaque

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6864e91e8b6483208135f754d34611db