### PR TITLE
Fix neon line layering in AboutProgram

### DIFF
--- a/src/components/AboutProgram/AboutProgram.module.css
+++ b/src/components/AboutProgram/AboutProgram.module.css
@@ -94,7 +94,7 @@
   width: 100%;
   height: 40px;
   filter: blur(4px);
-  z-index: 1;
+  z-index: 0;
 }
   
 


### PR DESCRIPTION
## Summary
- lower the z-index of AboutProgram neon line so it's behind the cards

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68651539000c8320a1f499a3d295e7f6