### PR TITLE
Adjust transparency of AboutProgram cards

### DIFF
--- a/src/components/AboutProgram/AboutProgram.module.css
+++ b/src/components/AboutProgram/AboutProgram.module.css
@@ -28,8 +28,7 @@
 }
   
   .card {
-    background-color: #fff;
-    opacity: 1;
+    background-color: rgba(255, 255, 255, 0.9);
     padding: 30px;
     position: relative;
     z-index: 1;


### PR DESCRIPTION
## Summary
- update card style so the neon line is slightly visible beneath

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68652cbf681c83208cf5c8ef8f94ca8f