### PR TITLE
Increase AboutProgram card transparency

### DIFF
--- a/src/components/AboutProgram/AboutProgram.module.css
+++ b/src/components/AboutProgram/AboutProgram.module.css
@@ -28,7 +28,7 @@
 }
   
   .card {
-    background-color: rgba(255, 255, 255, 0.9);
+    background-color: rgba(255, 255, 255, 0.7);
     padding: 30px;
     position: relative;
     z-index: 1;


### PR DESCRIPTION
## Summary
- adjust the AboutProgram card background opacity to 0.7

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68652d9aacd48320b81d38930c318cf5