### PR TITLE
Switch CourseStructure to single card

### DIFF
--- a/src/components/CourseStructure/CourseStructure.module.css
+++ b/src/components/CourseStructure/CourseStructure.module.css
@@ -13,35 +13,38 @@
     margin-bottom: 50px;
   }
   
-  .grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 40px;
-  }
-  
-  .card {
-    background-color: #f5f5f5;
-    padding: 28px;
-    border-radius: 20px;
-    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.03);
-    transition: transform 0.3s ease;
-  }
-  
-  .card:hover {
-    transform: translateY(-4px);
-  }
-  
-  .card h3 {
-    font-size: 18px;
-    font-weight: 600;
-    margin-bottom: 10px;
-    color: #222;
-  }
-  
-  .card p {
-    font-size: 16px;
-    line-height: 1.6;
-    color: #444;
-  }
+.card {
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid #e0e0e0;
+  border-radius: 24px;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.04);
+  padding: 40px;
+  max-width: 800px;
+  margin: 0 auto;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.08);
+}
+
+.item:not(:last-child) {
+  margin-bottom: 24px;
+}
+
+.item h3 {
+  font-size: 20px;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: #111;
+}
+
+.item p {
+  font-size: 16px;
+  line-height: 1.6;
+  color: #444;
+}
   
   

--- a/src/components/CourseStructure/CourseStructure.tsx
+++ b/src/components/CourseStructure/CourseStructure.tsx
@@ -20,9 +20,9 @@ const CourseStructure: React.FC = () => {
   return (
     <section className={styles.structure}>
       <h2 className={styles.title}>Структура курса</h2>
-      <div className={styles.grid}>
+      <div className={styles.card}>
         {items.map((item, index) => (
-          <div key={index} className={styles.card}>
+          <div key={index} className={styles.item}>
             <h3>{item.title}</h3>
             <p>{item.text}</p>
           </div>


### PR DESCRIPTION
## Summary
- replace the grid of three cards in CourseStructure with a single large card
- style the card to match the Hero and AboutProgram blocks

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68678ea87bec8320bfb5aa75a8fb7b58