### PR TITLE
Increase CourseStructure card height

### DIFF
--- a/src/components/CourseStructure/CourseStructure.module.css
+++ b/src/components/CourseStructure/CourseStructure.module.css
@@ -21,6 +21,11 @@
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.04);
   padding: 40px;
   max-width: 800px;
+  /*
+   Increase the minimum height so the card visually stretches
+   downward and occupies more space within the section.
+  */
+  min-height: 400px;
   margin: 0 auto;
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }


### PR DESCRIPTION
## Summary
- stretch the CourseStructure card by adding `min-height`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68678fdb21f08320b8aa585f56b362b4