### PR TITLE
Fix hero labels visibility

### DIFF
--- a/src/components/Hero/Hero.module.css
+++ b/src/components/Hero/Hero.module.css
@@ -65,7 +65,7 @@
   font-size: 18px;
   font-weight: 700;
   color: #111;
-  opacity: 0;
+  opacity: 1;
 }
 
 


### PR DESCRIPTION
## Summary
- fix hero card label style so titles remain visible

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6878dd25ca248320910df8ab5cfd3846