### PR TITLE
Add gradient background for Teachers

### DIFF
--- a/src/components/Teachers/Teachers.module.css
+++ b/src/components/Teachers/Teachers.module.css
@@ -1,7 +1,8 @@
 .teachers {
     min-height: 100vh;
     padding: 100px 20px;
-    background-color: #fdfbfb;
+    /* Smooth gradient from white at the top to light grey at the bottom */
+    background: linear-gradient(to bottom, #ffffff 0%, #f0f0f0 100%);
     max-width: 1200px;
     margin: 0 auto;
     text-align: center;


### PR DESCRIPTION
## Summary
- tweak Teachers section to use the same white-to-grey gradient used in other sections

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6878e1d7007c8320b684bb421e566588