### PR TITLE
Fix background gradient in reviews

### DIFF
--- a/src/components/Reviews/Reviews.module.css
+++ b/src/components/Reviews/Reviews.module.css
@@ -2,7 +2,7 @@
     min-height: 100vh;
     padding: 100px 20px;
     /* Match Teachers section background */
-    background: linear-gradient(to bottom, #ffffff 0%, #f0f0f0 100%);
+    background: linear-gradient(to bottom, #f0f0f0 0%, #ffffff 100%);
     position: relative;
     text-align: center;
     overflow: hidden;


### PR DESCRIPTION
## Summary
- adjust gradient so grey starts at the top and fades to white

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687a0b0b33648320b0683efbf25424c0